### PR TITLE
changing user display name and marking top songs in album details

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
-    <targetSelectedWithDropDown>
+    <runningDeviceTargetSelectedWithDropDown>
       <Target>
-        <type value="QUICK_BOOT_TARGET" />
+        <type value="RUNNING_DEVICE_TARGET" />
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="$USER_HOME$/.android/avd/Pixel_3a_XL_API_29.avd" />
+            <value value="$USER_HOME$/.android/avd/Pixel_3a_API_30.avd" />
           </Key>
         </deviceKey>
       </Target>
-    </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2022-07-05T18:48:58.284038Z" />
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2022-07-05T21:33:04.734959Z" />
   </component>
 </project>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -7,11 +7,11 @@
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="$USER_HOME$/.android/avd/Pixel_3a_API_30.avd" />
+            <value value="$USER_HOME$/.android/avd/Pixel_3a_XL_API_29.avd" />
           </Key>
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2022-07-05T17:17:19.417648Z" />
+    <timeTargetWasSelectedWithDropDown value="2022-07-05T18:48:58.284038Z" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,6 +8,7 @@
         <entry key="app/src/main/res/drawable/avd_post_like.xml" value="0.1" />
         <entry key="app/src/main/res/drawable/avd_post_unlike.xml" value="0.1" />
         <entry key="app/src/main/res/drawable/heart_selector.xml" value="0.1" />
+        <entry key="app/src/main/res/drawable/ic_baseline_star_24.xml" value="0.176" />
         <entry key="app/src/main/res/drawable/ic_collageify_logo.xml" value="0.165" />
         <entry key="app/src/main/res/drawable/ic_collageify_logo_white.xml" value="0.1765" />
         <entry key="app/src/main/res/drawable/ic_dashboard_black_24dp.xml" value="0.1095" />
@@ -31,7 +32,7 @@
         <entry key="app/src/main/res/layout/fragment_profile.xml" value="0.335" />
         <entry key="app/src/main/res/layout/item_post.xml" value="0.5" />
         <entry key="app/src/main/res/layout/item_profile_post.xml" value="0.28191489361702127" />
-        <entry key="app/src/main/res/layout/item_song.xml" value="0.2857142857142857" />
+        <entry key="app/src/main/res/layout/item_song.xml" value="0.5" />
         <entry key="app/src/main/res/layout/toolbar_main.xml" value="0.45" />
         <entry key="app/src/main/res/menu/bottom_nav_menu.xml" value="0.25189463297526044" />
         <entry key="app/src/main/res/menu/menu_bottom_nav.xml" value="0.6703703703703704" />

--- a/app/src/main/java/com/example/collageify/activities/ConnectSpotifyActivity.java
+++ b/app/src/main/java/com/example/collageify/activities/ConnectSpotifyActivity.java
@@ -39,12 +39,7 @@ public class ConnectSpotifyActivity extends AppCompatActivity {
 
         mSharedPreferences = this.getSharedPreferences("SPOTIFY", 0);
         queue = Volley.newRequestQueue(this);
-        binding.btnLoginSpotify.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                authenticateSpotify();
-            }
-        });
+        binding.btnLoginSpotify.setOnClickListener(v -> authenticateSpotify());
     }
 
     private void authenticateSpotify() {
@@ -64,7 +59,6 @@ public class ConnectSpotifyActivity extends AppCompatActivity {
             switch (response.getType()) {
                 case TOKEN:
                     // handle successful response
-
                     editor = getSharedPreferences("SPOTIFY", 0).edit();
                     editor.putString("token", response.getAccessToken());
                     editor.apply();
@@ -86,7 +80,7 @@ public class ConnectSpotifyActivity extends AppCompatActivity {
         UserService userService = new UserService(queue, mSharedPreferences);
         userService.get(() -> {
             User user = userService.getUser();
-            Toast.makeText(this, "authenticated as " + user.getSpotifyId(), Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, "authenticated as " + user.getSpotifyDisplayName(), Toast.LENGTH_SHORT).show();
             startMainActivity();
         });
     }

--- a/app/src/main/java/com/example/collageify/activities/MainActivity.java
+++ b/app/src/main/java/com/example/collageify/activities/MainActivity.java
@@ -3,20 +3,19 @@ package com.example.collageify.activities;
 import android.os.Bundle;
 import android.view.MenuItem;
 
-import com.example.collageify.R;
-import com.example.collageify.fragments.CollageFragment;
-import com.example.collageify.fragments.DetailFragment;
-import com.example.collageify.fragments.FeedFragment;
-import com.example.collageify.fragments.ProfileFragment;
-import com.example.collageify.models.Album;
-
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
+import com.example.collageify.R;
 import com.example.collageify.databinding.ActivityMainBinding;
+import com.example.collageify.fragments.CollageFragment;
+import com.example.collageify.fragments.DetailFragment;
+import com.example.collageify.fragments.FeedFragment;
+import com.example.collageify.fragments.ProfileFragment;
+import com.example.collageify.models.Album;
 import com.google.android.material.navigation.NavigationBarView;
 import com.parse.ParseUser;
 
@@ -37,27 +36,24 @@ public class MainActivity extends AppCompatActivity {
         collageFragment = new CollageFragment(MainActivity.this);
         final Fragment profileFragment = new ProfileFragment(ParseUser.getCurrentUser());
 
-        binding.bottomNavigation.setOnItemSelectedListener(new NavigationBarView.OnItemSelectedListener() {
-            @Override
-            public boolean onNavigationItemSelected(@NonNull MenuItem item) {
-                Fragment fragment;
-                switch (item.getItemId()) {
-                    case R.id.action_home:
-                        fragment = feedFragment;
-                        break;
-                    case R.id.action_collage:
-                        fragment = collageFragment;
-                        break;
-                    case R.id.action_profile:
-                        fragment = profileFragment;
-                        break;
-                    default:
-                        fragment = collageFragment;
-                        break;
-                }
-                fragmentManager.beginTransaction().replace(R.id.flContainer, fragment).commit();
-                return true;
+        binding.bottomNavigation.setOnItemSelectedListener(item -> {
+            Fragment fragment;
+            switch (item.getItemId()) {
+                case R.id.action_home:
+                    fragment = feedFragment;
+                    break;
+                case R.id.action_collage:
+                    fragment = collageFragment;
+                    break;
+                case R.id.action_profile:
+                    fragment = profileFragment;
+                    break;
+                default:
+                    fragment = collageFragment;
+                    break;
             }
+            fragmentManager.beginTransaction().replace(R.id.flContainer, fragment).commit();
+            return true;
         });
         // set default selection
         binding.bottomNavigation.setSelectedItemId(R.id.action_collage);

--- a/app/src/main/java/com/example/collageify/adapters/AlbumTracksAdapter.java
+++ b/app/src/main/java/com/example/collageify/adapters/AlbumTracksAdapter.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -17,11 +18,13 @@ import java.util.List;
 public class AlbumTracksAdapter extends RecyclerView.Adapter<AlbumTracksAdapter.ViewHolder> {
 
     private Context context;
+    private List<String> topTrackIds;
     private List<Song> tracks;
 
-    public AlbumTracksAdapter(Context context, List<Song> tracks) {
+    public AlbumTracksAdapter(Context context, List<Song> tracks, List<String> topTrackIds) {
         this.tracks = tracks;
         this.context = context;
+        this.topTrackIds = topTrackIds;
     }
 
     @NonNull
@@ -47,18 +50,26 @@ public class AlbumTracksAdapter extends RecyclerView.Adapter<AlbumTracksAdapter.
         public TextView tvTitle;
         public TextView tvDuration;
         public TextView tvNumber;
+        public ImageView ivStar;
 
         public ViewHolder(@NonNull View itemView) {
             super(itemView);
             tvTitle = itemView.findViewById(R.id.tvTitle);
             tvDuration = itemView.findViewById(R.id.tvDuration);
             tvNumber = itemView.findViewById(R.id.tvNumber);
+            ivStar = itemView.findViewById(R.id.ivStar);
         }
 
         public void bind(Song song) {
             tvTitle.setText(song.getName());
             tvNumber.setText(String.valueOf(song.getTrackNumber()));
             tvDuration.setText(song.getDuration());
+            // show star if song is a top track
+            if (topTrackIds.contains(song.getId())) {
+                ivStar.setVisibility(View.VISIBLE);
+            } else {
+                ivStar.setVisibility(View.GONE);
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/collageify/fragments/DetailFragment.java
+++ b/app/src/main/java/com/example/collageify/fragments/DetailFragment.java
@@ -67,7 +67,7 @@ public class DetailFragment extends Fragment {
         getArtistInfo();
 
         albumTracks = new ArrayList<>();
-        adapter = new AlbumTracksAdapter(getContext(), albumTracks);
+        adapter = new AlbumTracksAdapter(getContext(), albumTracks, album.getTopSongIds());
         binding.rvSongs.setAdapter(adapter);
         binding.rvSongs.setLayoutManager(new LinearLayoutManager(getContext()));
         getAlbumTracksInfo();

--- a/app/src/main/java/com/example/collageify/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/example/collageify/fragments/ProfileFragment.java
@@ -65,9 +65,6 @@ public class ProfileFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
         binding.tvProfileUsername.setText(user.getUsername());
         String spotifyName = user.getSpotifyDisplayName();
-        if (spotifyName.isEmpty()) {
-            spotifyName = user.getSpotifyId();
-        }
         binding.tvSpotifyId.setText(String.format("%s on Spotify", spotifyName));
         // initialize array that will hold posts and create PostsAdapter
         allPosts = new ArrayList<>();

--- a/app/src/main/java/com/example/collageify/models/Album.java
+++ b/app/src/main/java/com/example/collageify/models/Album.java
@@ -3,6 +3,9 @@ package com.example.collageify.models;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class Album {
 
     private String name;
@@ -10,12 +13,12 @@ public class Album {
     private String artistHref;
     private String artistName;
     private final int ranking; // based on position of top song in top tracks list
-    private int songCount;
     private String id;
     private String uri;
+    private final List<String> topSongIds;
 
     public Album(JSONObject albumData, int ranking) {
-        songCount = 1;
+        topSongIds = new ArrayList<>();
         this.ranking = ranking;
         try {
             id = albumData.getString("id");
@@ -35,12 +38,8 @@ public class Album {
         return imageUrl;
     }
 
-    public void incrementSongCount() {
-        songCount++;
-    }
-
     public int getSongCount() {
-        return songCount;
+        return topSongIds.size();
     }
 
     public int getRanking() {
@@ -65,5 +64,13 @@ public class Album {
 
     public String getUri() {
         return uri;
+    }
+
+    public void addTopSong(Song song) {
+        topSongIds.add(song.getId());
+    }
+
+    public List<String> getTopSongIds() {
+        return topSongIds;
     }
 }

--- a/app/src/main/java/com/example/collageify/models/Song.java
+++ b/app/src/main/java/com/example/collageify/models/Song.java
@@ -55,4 +55,8 @@ public class Song {
     public String getDuration() {
         return duration;
     }
+
+    public String getId() {
+        return id;
+    }
 }

--- a/app/src/main/java/com/example/collageify/models/User.java
+++ b/app/src/main/java/com/example/collageify/models/User.java
@@ -3,10 +3,7 @@ package com.example.collageify.models;
 import android.util.Log;
 
 import com.parse.ParseClassName;
-import com.parse.ParseException;
 import com.parse.ParseUser;
-import com.parse.SaveCallback;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -17,6 +14,7 @@ public class User extends ParseUser {
     public static final String KEY_SPOTIFY_ID = "spotifyId";
     private static final String TAG = "User";
     public static final String KEY_PFP_URL = "profilePicUrl";
+    public static final String KEY_SPOTIFY_DISPLAY_NAME = "spotifyDisplayName";
 
     public String getSpotifyId() {
         return getString(KEY_SPOTIFY_ID);
@@ -34,9 +32,18 @@ public class User extends ParseUser {
         put(KEY_PFP_URL, id);
     }
 
+    public void setSpotifyDisplayName(String name) {
+        put(KEY_SPOTIFY_DISPLAY_NAME, name);
+    }
+
+    public String getSpotifyDisplayName() {
+        return getString(KEY_SPOTIFY_DISPLAY_NAME);
+    }
+
     public void setSpotifyInfo(JSONObject jsonObject) {
         try {
             setSpotifyId(jsonObject.getString("id"));
+            setSpotifyDisplayName(jsonObject.getString("display_name"));
             JSONArray images = jsonObject.getJSONArray("images");
             if (images.length() > 0) {
                 setPfpUrl(images.getJSONObject(0).getString("url"));

--- a/app/src/main/java/com/example/collageify/models/User.java
+++ b/app/src/main/java/com/example/collageify/models/User.java
@@ -42,8 +42,14 @@ public class User extends ParseUser {
 
     public void setSpotifyInfo(JSONObject jsonObject) {
         try {
-            setSpotifyId(jsonObject.getString("id"));
-            setSpotifyDisplayName(jsonObject.getString("display_name"));
+            String spotifyId = jsonObject.getString("id");
+            setSpotifyId(spotifyId);
+            String spotifyName = jsonObject.getString("display_name");
+            if (spotifyName != null) {
+                setSpotifyDisplayName(spotifyName);
+            } else {
+                setSpotifyDisplayName(spotifyId);
+            }
             JSONArray images = jsonObject.getJSONArray("images");
             if (images.length() > 0) {
                 setPfpUrl(images.getJSONObject(0).getString("url"));

--- a/app/src/main/java/com/example/collageify/services/SongService.java
+++ b/app/src/main/java/com/example/collageify/services/SongService.java
@@ -4,15 +4,12 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Log;
 
-import com.android.volley.AuthFailureError;
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.JsonObjectRequest;
-import com.android.volley.toolbox.JsonRequest;
 import com.android.volley.toolbox.Volley;
 import com.example.collageify.VolleyCallBack;
 import com.example.collageify.models.Song;
-import com.google.gson.Gson;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -54,9 +51,7 @@ public class SongService {
                         }
                     }
                     callBack.onSuccess();
-                }, error -> {
-                    Log.e(TAG, "an error occurred when fetching top tracks", error);
-                }) {
+                }, error -> Log.e(TAG, "an error occurred when fetching top tracks", error)) {
             @Override
             public Map<String, String> getHeaders() {
                 Map<String, String> headers = new HashMap<>();

--- a/app/src/main/java/com/example/collageify/utils/TopAlbumsUtil.java
+++ b/app/src/main/java/com/example/collageify/utils/TopAlbumsUtil.java
@@ -27,12 +27,10 @@ public class TopAlbumsUtil {
         for (int i = 0; i < songs.size(); i++) {
             Song song = songs.get(i);
             String albumId = song.getAlbumId();
-            Album album = albums.get(albumId);
-            if (album != null) {
-                albums.get(albumId).incrementSongCount();
-            } else {
+            if (!albums.containsKey(albumId)) {
                 albums.put(albumId, new Album(song.getAlbumData(), i));
             }
+            albums.get(albumId).addTopSong(song);
         }
         topAlbums.clear();
         topAlbums.addAll(albums.values());

--- a/app/src/main/res/drawable/ic_baseline_star_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_star_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="@color/green"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_collage.xml
+++ b/app/src/main/res/layout/fragment_collage.xml
@@ -14,7 +14,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.4" />
+        app:layout_constraintVertical_bias="0.4"/>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/constraintLayout"

--- a/app/src/main/res/layout/item_song.xml
+++ b/app/src/main/res/layout/item_song.xml
@@ -30,4 +30,13 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="1" />
+
+    <ImageView
+        android:id="@+id/ivStar"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:layout_marginStart="8dp"
+        app:layout_constraintStart_toEndOf="@+id/tvTitle"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_baseline_star_24" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
- Changed Spotify name on ProfileFragment to user display name instead of Spotify id, since many users have Spotify ids that are purely numerical
- Marked top songs in album details with green stars by storing a list of top song ids and referencing that list in the AlbumTracksAdapter

![Screenshot_20220705_155607](https://user-images.githubusercontent.com/52613733/177430553-236daf9a-b87d-400a-8508-fd7080582ab3.jpeg)
