### PR TITLE
adding to album details: back button and tabs

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -28,6 +28,10 @@
         <entry key="app/src/main/res/layout/activity_login.xml" value="0.26038500506585616" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.375" />
         <entry key="app/src/main/res/layout/activity_signup.xml" value="0.16945288753799392" />
+        <entry key="app/src/main/res/layout/fragment_album_detail_tabs.xml" value="0.28292806484295846" />
+        <entry key="app/src/main/res/layout/fragment_album_more.xml" value="0.30927051671732525" />
+        <entry key="app/src/main/res/layout/fragment_album_songs.xml" value="0.15070921985815602" />
+        <entry key="app/src/main/res/layout/fragment_album_stats.xml" value="0.30927051671732525" />
         <entry key="app/src/main/res/layout/fragment_collage.xml" value="0.25" />
         <entry key="app/src/main/res/layout/fragment_detail.xml" value="0.2862208713272543" />
         <entry key="app/src/main/res/layout/fragment_feed.xml" value="0.335" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,11 +3,13 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
+        <entry key="../../../../../layout/custom_preview.xml" value="0.2378419452887538" />
         <entry key="app/src/main/res/drawable-v24/avd_post_like.xml" value="0.119" />
         <entry key="app/src/main/res/drawable-v24/ic_launcher_foreground.xml" value="0.1095" />
         <entry key="app/src/main/res/drawable/avd_post_like.xml" value="0.1" />
         <entry key="app/src/main/res/drawable/avd_post_unlike.xml" value="0.1" />
         <entry key="app/src/main/res/drawable/heart_selector.xml" value="0.1" />
+        <entry key="app/src/main/res/drawable/ic_baseline_arrow_back_24.xml" value="0.378" />
         <entry key="app/src/main/res/drawable/ic_baseline_star_24.xml" value="0.176" />
         <entry key="app/src/main/res/drawable/ic_collageify_logo.xml" value="0.165" />
         <entry key="app/src/main/res/drawable/ic_collageify_logo_white.xml" value="0.1765" />

--- a/app/src/main/java/com/example/collageify/activities/MainActivity.java
+++ b/app/src/main/java/com/example/collageify/activities/MainActivity.java
@@ -1,9 +1,7 @@
 package com.example.collageify.activities;
 
 import android.os.Bundle;
-import android.view.MenuItem;
 
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
@@ -12,11 +10,10 @@ import androidx.fragment.app.FragmentTransaction;
 import com.example.collageify.R;
 import com.example.collageify.databinding.ActivityMainBinding;
 import com.example.collageify.fragments.CollageFragment;
-import com.example.collageify.fragments.DetailFragment;
+import com.example.collageify.fragments.AlbumDetailFragment;
 import com.example.collageify.fragments.FeedFragment;
 import com.example.collageify.fragments.ProfileFragment;
 import com.example.collageify.models.Album;
-import com.google.android.material.navigation.NavigationBarView;
 import com.parse.ParseUser;
 
 public class MainActivity extends AppCompatActivity {
@@ -24,6 +21,7 @@ public class MainActivity extends AppCompatActivity {
     private ActivityMainBinding binding;
     private Fragment collageFragment;
     private FragmentManager fragmentManager;
+    private AlbumDetailFragment detailFragment;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -63,19 +61,20 @@ public class MainActivity extends AppCompatActivity {
         binding.bottomNavigation.setSelectedItemId(R.id.action_home);
     }
 
-    public void goToDetailFrag(Album album) {
+    public void goToAlbumDetailFrag(Album album) {
         FragmentTransaction ft = fragmentManager.beginTransaction();
         ft.hide(collageFragment);
-        DetailFragment detailFragment = new DetailFragment(album);
+        detailFragment = new AlbumDetailFragment(album);
         ft.add(R.id.flContainer, detailFragment);
         ft.addToBackStack("collage to detail");
         ft.show(detailFragment);
         ft.commit();
     }
 
-    public void goToCollageFrag(Album album) {
+    public void goToCollageFrag() {
         FragmentTransaction ft = fragmentManager.beginTransaction();
-        ft.replace(R.id.flContainer, collageFragment);
+        ft.hide(detailFragment);
+        ft.show(collageFragment);
         ft.commit();
     }
 

--- a/app/src/main/java/com/example/collageify/adapters/AlbumDetailTabsAdapter.java
+++ b/app/src/main/java/com/example/collageify/adapters/AlbumDetailTabsAdapter.java
@@ -1,0 +1,43 @@
+package com.example.collageify.adapters;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+import androidx.viewpager2.adapter.FragmentStateAdapter;
+
+import com.example.collageify.fragments.AlbumMoreFragment;
+import com.example.collageify.fragments.AlbumSongsFragment;
+import com.example.collageify.fragments.AlbumStatsFragment;
+import com.example.collageify.models.Album;
+
+public class AlbumDetailTabsAdapter extends FragmentStateAdapter {
+
+    public static String[] tabs = {"songs", "stats", "more"};
+    private int numTabs;
+    private Album album;
+
+    public AlbumDetailTabsAdapter(@NonNull Fragment fragment, int numTabs, Album album) {
+        super(fragment);
+        this.numTabs = numTabs;
+        this.album = album;
+    }
+
+    @NonNull
+    @Override
+    public Fragment createFragment(int position) {
+        switch (position) {
+            case 0:
+                return new AlbumSongsFragment(album);
+            case 1:
+                return new AlbumStatsFragment();
+            case 2:
+                return new AlbumMoreFragment();
+            default: // should not reach here
+                return null;
+        }
+    }
+
+    @Override
+    public int getItemCount() {
+        return numTabs;
+    }
+}

--- a/app/src/main/java/com/example/collageify/adapters/AlbumsAdapter.java
+++ b/app/src/main/java/com/example/collageify/adapters/AlbumsAdapter.java
@@ -1,7 +1,6 @@
 package com.example.collageify.adapters;
 
 import android.content.Context;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -66,7 +65,7 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
             int position = getAdapterPosition();
             if (position != RecyclerView.NO_POSITION) {
                 Album album = albums.get(position);
-                ((MainActivity) context).goToDetailFrag(album);
+                ((MainActivity) context).goToAlbumDetailFrag(album);
             }
         }
     }

--- a/app/src/main/java/com/example/collageify/fragments/AlbumDetailFragment.java
+++ b/app/src/main/java/com/example/collageify/fragments/AlbumDetailFragment.java
@@ -1,32 +1,26 @@
 package com.example.collageify.fragments;
 
 import android.os.Bundle;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
-import androidx.recyclerview.widget.LinearLayoutManager;
-
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
 import com.bumptech.glide.Glide;
-import com.example.collageify.activities.ConnectSpotifyActivity;
 import com.example.collageify.activities.MainActivity;
+import com.example.collageify.adapters.AlbumDetailTabsAdapter;
 import com.example.collageify.adapters.AlbumTracksAdapter;
 import com.example.collageify.databinding.FragmentAlbumDetailBinding;
-import com.example.collageify.models.Song;
-import com.example.collageify.services.AlbumTracksService;
-import com.example.collageify.services.ArtistService;
 import com.example.collageify.models.Album;
 import com.example.collageify.models.Artist;
-import com.spotify.android.appremote.api.ConnectionParams;
-import com.spotify.android.appremote.api.Connector;
+import com.example.collageify.models.Song;
+import com.example.collageify.services.ArtistService;
+import com.google.android.material.tabs.TabLayoutMediator;
 import com.spotify.android.appremote.api.SpotifyAppRemote;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -66,43 +60,13 @@ public class AlbumDetailFragment extends Fragment {
         Glide.with(getContext()).load(album.getImageUrl()).into(binding.ivAlbumImage);
         getArtistInfo();
 
-        albumTracks = new ArrayList<>();
-        adapter = new AlbumTracksAdapter(getContext(), albumTracks, album.getTopSongIds());
-        binding.rvSongs.setAdapter(adapter);
-        binding.rvSongs.setLayoutManager(new LinearLayoutManager(getContext()));
-        getAlbumTracksInfo();
-
-        binding.btnPlayOnSpotify.setOnClickListener(v -> playOnSpotify());
         binding.ibBack.setOnClickListener(v -> ((MainActivity) getContext()).goToCollageFrag());
 
-    }
+        AlbumDetailTabsAdapter albumDetailTabsAdapter = new AlbumDetailTabsAdapter(this, binding.tabLayout.getTabCount(), album);
+        binding.pager.setAdapter(albumDetailTabsAdapter);
 
-    private void playOnSpotify() {
-        ConnectionParams connectionParams = new ConnectionParams.Builder(ConnectSpotifyActivity.CLIENT_ID)
-                .setRedirectUri(ConnectSpotifyActivity.REDIRECT_URI)
-                .showAuthView(true)
-                .build();
-        SpotifyAppRemote.connect(getContext(), connectionParams, new Connector.ConnectionListener() {
-            @Override
-            public void onConnected(SpotifyAppRemote spotifyAppRemote) {
-                mSpotifyAppRemote = spotifyAppRemote;
-                Log.i(TAG, "connected to spotify player");
-                mSpotifyAppRemote.getPlayerApi().play(album.getUri());
-            }
-
-            @Override
-            public void onFailure(Throwable error) {
-                Log.e(TAG, error.getMessage(), error);
-            }
-        });
-    }
-
-    private void getAlbumTracksInfo() {
-        AlbumTracksService albumTracksService = new AlbumTracksService(getContext().getApplicationContext());
-        albumTracksService.get(album.getId(), () -> {
-            albumTracks.addAll(albumTracksService.getAlbumTracks());
-            adapter.notifyDataSetChanged();
-        });
+        new TabLayoutMediator(binding.tabLayout, binding.pager,
+                (tab, position) -> tab.setText(AlbumDetailTabsAdapter.tabs[position])).attach();
     }
 
     private void getArtistInfo() {

--- a/app/src/main/java/com/example/collageify/fragments/AlbumDetailFragment.java
+++ b/app/src/main/java/com/example/collageify/fragments/AlbumDetailFragment.java
@@ -14,39 +14,39 @@ import android.view.ViewGroup;
 
 import com.bumptech.glide.Glide;
 import com.example.collageify.activities.ConnectSpotifyActivity;
+import com.example.collageify.activities.MainActivity;
 import com.example.collageify.adapters.AlbumTracksAdapter;
+import com.example.collageify.databinding.FragmentAlbumDetailBinding;
 import com.example.collageify.models.Song;
 import com.example.collageify.services.AlbumTracksService;
 import com.example.collageify.services.ArtistService;
-import com.example.collageify.databinding.FragmentDetailBinding;
 import com.example.collageify.models.Album;
 import com.example.collageify.models.Artist;
 import com.spotify.android.appremote.api.ConnectionParams;
 import com.spotify.android.appremote.api.Connector;
 import com.spotify.android.appremote.api.SpotifyAppRemote;
 
-import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * A simple {@link Fragment} subclass.
  */
-public class DetailFragment extends Fragment {
+public class AlbumDetailFragment extends Fragment {
 
-    private FragmentDetailBinding binding;
+    private FragmentAlbumDetailBinding binding;
     private Album album;
     private Artist albumArtist;
     private List<Song> albumTracks;
     private AlbumTracksAdapter adapter;
     private SpotifyAppRemote mSpotifyAppRemote;
-    public static final String TAG = "DetailFragment";
+    public static final String TAG = "AlbumDetailFragment";
 
-    public DetailFragment() {
+    public AlbumDetailFragment() {
         // Required empty public constructor
     }
 
-    public DetailFragment(Album album) {
+    public AlbumDetailFragment(Album album) {
         this.album = album;
     }
 
@@ -54,7 +54,7 @@ public class DetailFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
-        binding = FragmentDetailBinding.inflate(inflater, container, false);
+        binding = FragmentAlbumDetailBinding.inflate(inflater, container, false);
         return binding.getRoot();
     }
 
@@ -72,12 +72,8 @@ public class DetailFragment extends Fragment {
         binding.rvSongs.setLayoutManager(new LinearLayoutManager(getContext()));
         getAlbumTracksInfo();
 
-        binding.btnPlayOnSpotify.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                playOnSpotify();
-            }
-        });
+        binding.btnPlayOnSpotify.setOnClickListener(v -> playOnSpotify());
+        binding.ibBack.setOnClickListener(v -> ((MainActivity) getContext()).goToCollageFrag());
 
     }
 

--- a/app/src/main/java/com/example/collageify/fragments/AlbumMoreFragment.java
+++ b/app/src/main/java/com/example/collageify/fragments/AlbumMoreFragment.java
@@ -1,0 +1,28 @@
+package com.example.collageify.fragments;
+
+import android.os.Bundle;
+
+import androidx.fragment.app.Fragment;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.example.collageify.R;
+
+/**
+ * A simple {@link Fragment} subclass.
+ */
+public class AlbumMoreFragment extends Fragment {
+
+    public AlbumMoreFragment() {
+        // Required empty public constructor
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_album_more, container, false);
+    }
+}

--- a/app/src/main/java/com/example/collageify/fragments/AlbumSongsFragment.java
+++ b/app/src/main/java/com/example/collageify/fragments/AlbumSongsFragment.java
@@ -1,0 +1,106 @@
+package com.example.collageify.fragments;
+
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
+
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.example.collageify.R;
+import com.example.collageify.activities.ConnectSpotifyActivity;
+import com.example.collageify.adapters.AlbumTracksAdapter;
+import com.example.collageify.databinding.FragmentAlbumSongsBinding;
+import com.example.collageify.models.Album;
+import com.example.collageify.models.Song;
+import com.example.collageify.services.AlbumTracksService;
+import com.spotify.android.appremote.api.ConnectionParams;
+import com.spotify.android.appremote.api.Connector;
+import com.spotify.android.appremote.api.SpotifyAppRemote;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A simple {@link Fragment} subclass.
+ */
+public class AlbumSongsFragment extends Fragment {
+
+    private FragmentAlbumSongsBinding binding;
+    private Album album;
+    private List<Song> albumTracks;
+    private AlbumTracksAdapter adapter;
+    private SpotifyAppRemote mSpotifyAppRemote;
+    public static final String TAG = "AlbumSongsFragment";
+
+    public AlbumSongsFragment() {
+        // Required empty public constructor
+    }
+
+    public AlbumSongsFragment(Album album) {
+        this.album = album;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        binding = FragmentAlbumSongsBinding.inflate(inflater, container, false);
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        albumTracks = new ArrayList<>();
+        adapter = new AlbumTracksAdapter(getContext(), albumTracks, album.getTopSongIds());
+        getAlbumTracksInfo();
+
+        binding.rvSongs.setAdapter(adapter);
+        binding.rvSongs.setLayoutManager(new LinearLayoutManager(getContext()));
+        binding.btnPlayOnSpotify.setOnClickListener(v -> playOnSpotify());
+    }
+
+    private void getAlbumTracksInfo() {
+        AlbumTracksService albumTracksService = new AlbumTracksService(getContext().getApplicationContext());
+        albumTracksService.get(album.getId(), () -> {
+            albumTracks.addAll(albumTracksService.getAlbumTracks());
+            adapter.notifyDataSetChanged();
+        });
+    }
+
+    private void playOnSpotify() {
+        ConnectionParams connectionParams = new ConnectionParams.Builder(ConnectSpotifyActivity.CLIENT_ID)
+                .setRedirectUri(ConnectSpotifyActivity.REDIRECT_URI)
+                .showAuthView(true)
+                .build();
+        SpotifyAppRemote.connect(getContext(), connectionParams, new Connector.ConnectionListener() {
+            @Override
+            public void onConnected(SpotifyAppRemote spotifyAppRemote) {
+                mSpotifyAppRemote = spotifyAppRemote;
+                mSpotifyAppRemote.getPlayerApi().play(album.getUri());
+            }
+
+            @Override
+            public void onFailure(Throwable error) {
+                Log.e(TAG, error.getMessage(), error);
+            }
+        });
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
+}

--- a/app/src/main/java/com/example/collageify/fragments/AlbumStatsFragment.java
+++ b/app/src/main/java/com/example/collageify/fragments/AlbumStatsFragment.java
@@ -1,0 +1,33 @@
+package com.example.collageify.fragments;
+
+import android.os.Bundle;
+
+import androidx.fragment.app.Fragment;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.example.collageify.R;
+
+/**
+ * A simple {@link Fragment} subclass.
+ */
+public class AlbumStatsFragment extends Fragment {
+
+    public AlbumStatsFragment() {
+        // Required empty public constructor
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_album_stats, container, false);
+    }
+}

--- a/app/src/main/java/com/example/collageify/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/example/collageify/fragments/ProfileFragment.java
@@ -2,6 +2,10 @@ package com.example.collageify.fragments;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -9,11 +13,6 @@ import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
-
-import android.util.Log;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
 
 import com.bumptech.glide.Glide;
 import com.example.collageify.R;
@@ -23,8 +22,6 @@ import com.example.collageify.adapters.ProfilePostsAdapter;
 import com.example.collageify.databinding.FragmentProfileBinding;
 import com.example.collageify.models.Post;
 import com.example.collageify.models.User;
-import com.parse.FindCallback;
-import com.parse.ParseException;
 import com.parse.ParseQuery;
 import com.parse.ParseUser;
 import com.spotify.sdk.android.auth.AuthorizationClient;

--- a/app/src/main/res/drawable/ic_baseline_arrow_back_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_arrow_back_24.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="40dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24" android:width="40dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_arrow_back_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_arrow_back_24.xml
@@ -1,5 +1,5 @@
-<vector android:autoMirrored="true" android:height="40dp"
+<vector android:autoMirrored="true" android:height="30dp"
     android:viewportHeight="24"
-    android:viewportWidth="24" android:width="40dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    android:viewportWidth="24" android:width="30dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="@android:color/white" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
 </vector>

--- a/app/src/main/res/layout/fragment_album_detail.xml
+++ b/app/src/main/res/layout/fragment_album_detail.xml
@@ -11,7 +11,7 @@
         android:id="@+id/tvName"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
+        android:layout_marginTop="8dp"
         android:text=""
         android:textAlignment="center"
         android:textAppearance="@style/TextAppearance.AppCompat.Large"
@@ -22,8 +22,8 @@
 
     <ImageView
         android:id="@+id/ivAlbumImage"
-        android:layout_width="200dp"
-        android:layout_height="200dp"
+        android:layout_width="175dp"
+        android:layout_height="175dp"
         android:layout_marginTop="32dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.498"
@@ -33,10 +33,10 @@
 
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/constraintLayout2"
+        android:id="@+id/constraintLayoutArtist"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="4dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/tvName">
@@ -73,7 +73,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/constraintLayout2" />
+        app:layout_constraintTop_toBottomOf="@+id/constraintLayoutArtist" />
 
     <Button
         android:id="@+id/btnPlayOnSpotify"
@@ -84,6 +84,17 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
+
+    <ImageButton
+        android:id="@+id/ibBack"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:background="@null"
+        android:src="@drawable/ic_baseline_arrow_back_24"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_album_detail.xml
+++ b/app/src/main/res/layout/fragment_album_detail.xml
@@ -64,26 +64,26 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rvSongs"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginTop="8dp"
-        android:padding="10dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/constraintLayoutArtist" />
+<!--    <androidx.recyclerview.widget.RecyclerView-->
+<!--        android:id="@+id/rvSongs"-->
+<!--        android:layout_width="0dp"-->
+<!--        android:layout_height="0dp"-->
+<!--        android:layout_marginTop="8dp"-->
+<!--        android:padding="10dp"-->
+<!--        app:layout_constraintBottom_toBottomOf="parent"-->
+<!--        app:layout_constraintEnd_toEndOf="parent"-->
+<!--        app:layout_constraintStart_toStartOf="parent"-->
+<!--        app:layout_constraintTop_toBottomOf="@+id/constraintLayoutArtist" />-->
 
-    <Button
-        android:id="@+id/btnPlayOnSpotify"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
-        android:text="play on Spotify"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+<!--    <Button-->
+<!--        android:id="@+id/btnPlayOnSpotify"-->
+<!--        android:layout_width="wrap_content"-->
+<!--        android:layout_height="wrap_content"-->
+<!--        android:layout_marginBottom="16dp"-->
+<!--        android:text="play on Spotify"-->
+<!--        app:layout_constraintBottom_toBottomOf="parent"-->
+<!--        app:layout_constraintEnd_toEndOf="parent"-->
+<!--        app:layout_constraintStart_toStartOf="parent" />-->
 
     <ImageButton
         android:id="@+id/ibBack"
@@ -96,5 +96,38 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/tabLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/constraintLayoutArtist">
+
+        <com.google.android.material.tabs.TabItem
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Songs" />
+
+        <com.google.android.material.tabs.TabItem
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Stats" />
+
+        <com.google.android.material.tabs.TabItem
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="More" />
+    </com.google.android.material.tabs.TabLayout>
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/pager"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tabLayout"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_album_more.xml
+++ b/app/src/main/res/layout/fragment_album_more.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".fragments.AlbumMoreFragment">
+
+    <!-- TODO: Update blank fragment layout -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="more" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_album_songs.xml
+++ b/app/src/main/res/layout/fragment_album_songs.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvSongs"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:padding="10dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/btnPlayOnSpotify"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:text="play on Spotify"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_album_stats.xml
+++ b/app/src/main/res/layout/fragment_album_stats.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".fragments.AlbumStatsFragment">
+
+    <!-- TODO: Update blank fragment layout -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="stats" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/item_song.xml
+++ b/app/src/main/res/layout/item_song.xml
@@ -8,7 +8,7 @@
 
     <TextView
         android:id="@+id/tvTitle"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         app:layout_constraintStart_toEndOf="@+id/tvNumber"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,6 @@
         <item>last 6 months</item>
         <item>all time</item>
     </string-array>
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>


### PR DESCRIPTION
- added back button on album details screen so that users can easily navigate back to collage screen 
- added tabs in album details screen for songs, stats, and more using TabLayout and ViewPager2
     - "songs" tab shows list of songs and lets users play song on Spotify (ensured that these features still work after moving to new fragment for the view pager)
     - "stats" tab will show stats about the album
     - the "more" tab might be changed to a different name later, though I plan to include suggestions here
     - can navigate between tabs by swiping or by clicking on a tab
 

![ezgif com-gif-maker   ##(1)](https://user-images.githubusercontent.com/52613733/177847484-b2ece422-91b7-4b13-8afa-3a287ae50849.gif)
