### PR TITLE
cleaning code and removing adapter view binding

### DIFF
--- a/app/src/main/java/com/example/collageify/adapters/AlbumTracksAdapter.java
+++ b/app/src/main/java/com/example/collageify/adapters/AlbumTracksAdapter.java
@@ -4,11 +4,13 @@ import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.example.collageify.databinding.ItemSongBinding;
+import com.example.collageify.R;
 import com.example.collageify.models.Song;
 
 import java.util.List;
@@ -18,7 +20,6 @@ public class AlbumTracksAdapter extends RecyclerView.Adapter<AlbumTracksAdapter.
     private final Context context;
     private final List<String> topTrackIds;
     private final List<Song> tracks;
-    private ItemSongBinding binding;
 
     public AlbumTracksAdapter(Context context, List<Song> tracks, List<String> topTrackIds) {
         this.tracks = tracks;
@@ -29,8 +30,8 @@ public class AlbumTracksAdapter extends RecyclerView.Adapter<AlbumTracksAdapter.
     @NonNull
     @Override
     public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        binding = ItemSongBinding.inflate(LayoutInflater.from(context), parent, false);
-        return new ViewHolder(binding);
+        View view = LayoutInflater.from(context).inflate(R.layout.item_song, parent, false);
+        return new ViewHolder(view);
     }
 
     @Override
@@ -46,19 +47,28 @@ public class AlbumTracksAdapter extends RecyclerView.Adapter<AlbumTracksAdapter.
 
     public class ViewHolder extends RecyclerView.ViewHolder {
 
-        public ViewHolder(ItemSongBinding binding) {
-            super(binding.getRoot());
+        public TextView tvTitle;
+        public TextView tvDuration;
+        public TextView tvNumber;
+        public ImageView ivStar;
+
+        public ViewHolder(@NonNull View itemView) {
+            super(itemView);
+            tvTitle = itemView.findViewById(R.id.tvTitle);
+            tvDuration = itemView.findViewById(R.id.tvDuration);
+            tvNumber = itemView.findViewById(R.id.tvNumber);
+            ivStar = itemView.findViewById(R.id.ivStar);
         }
 
         public void bind(Song song) {
-            binding.tvTitle.setText(song.getName());
-            binding.tvNumber.setText(String.valueOf(song.getTrackNumber()));
-            binding.tvDuration.setText(song.getDuration());
+            tvTitle.setText(song.getName());
+            tvNumber.setText(String.valueOf(song.getTrackNumber()));
+            tvDuration.setText(song.getDuration());
             // show star if song is a top track
             if (topTrackIds.contains(song.getId())) {
-                binding.ivStar.setVisibility(View.VISIBLE);
+                ivStar.setVisibility(View.VISIBLE);
             } else {
-                binding.ivStar.setVisibility(View.GONE);
+                ivStar.setVisibility(View.GONE);
             }
         }
     }

--- a/app/src/main/java/com/example/collageify/adapters/AlbumsAdapter.java
+++ b/app/src/main/java/com/example/collageify/adapters/AlbumsAdapter.java
@@ -12,7 +12,6 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.bumptech.glide.Glide;
 import com.example.collageify.R;
 import com.example.collageify.activities.MainActivity;
-import com.example.collageify.databinding.ItemAlbumBinding;
 import com.example.collageify.models.Album;
 
 import java.util.List;
@@ -22,7 +21,6 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
     private final Context context;
     private final List<Album> albums;
     public static final String TAG = "AlbumsAdapter";
-    private ItemAlbumBinding binding;
 
     public AlbumsAdapter(Context context, List<Album> albums) {
         this.context = context;
@@ -32,8 +30,8 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
     @NonNull
     @Override
     public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        binding = ItemAlbumBinding.inflate(LayoutInflater.from(context), parent, false);
-        return new ViewHolder(binding);
+        View view = LayoutInflater.from(context).inflate(R.layout.item_album, parent, false);
+        return new ViewHolder(view);
     }
 
     @Override
@@ -49,15 +47,17 @@ public class AlbumsAdapter extends RecyclerView.Adapter<AlbumsAdapter.ViewHolder
 
     public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
+        public ImageView ivImage;
 
-        public ViewHolder(@NonNull ItemAlbumBinding binding) {
-            super(binding.getRoot());
-            binding.getRoot().setOnClickListener(this);
+        public ViewHolder(@NonNull View itemView) {
+            super(itemView);
+            itemView.setOnClickListener(this);
+            ivImage = itemView.findViewById(R.id.ivImage);
         }
 
         public void bind(Album album) {
             String imageUrl = album.getImageUrl();
-            Glide.with(context).load(imageUrl).into(binding.ivImage);
+            Glide.with(context).load(imageUrl).into(ivImage);
         }
 
         @Override

--- a/app/src/main/java/com/example/collageify/adapters/PostsAdapter.java
+++ b/app/src/main/java/com/example/collageify/adapters/PostsAdapter.java
@@ -2,7 +2,6 @@ package com.example.collageify.adapters;
 
 import android.content.Context;
 import android.graphics.drawable.AnimatedVectorDrawable;
-import android.graphics.drawable.Drawable;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -63,7 +62,6 @@ public class PostsAdapter extends RecyclerView.Adapter<PostsAdapter.ViewHolder> 
         private final TextView tvLikes;
         private final ImageView ivPfp;
         private final ImageView ivHeart;
-        private AnimatedVectorDrawable avd;
 
         public ViewHolder(@NonNull View itemView) {
             super(itemView);
@@ -143,7 +141,7 @@ public class PostsAdapter extends RecyclerView.Adapter<PostsAdapter.ViewHolder> 
                 // like
                 post.like();
                 ivHeart.setAlpha(0.85f);
-                avd = (AnimatedVectorDrawable) ivHeart.getDrawable();
+                AnimatedVectorDrawable avd = (AnimatedVectorDrawable) ivHeart.getDrawable();
                 avd.start();
                 ibLike.setSelected(true);
             }

--- a/app/src/main/java/com/example/collageify/adapters/RecommendedTracksAdapter.java
+++ b/app/src/main/java/com/example/collageify/adapters/RecommendedTracksAdapter.java
@@ -2,22 +2,24 @@ package com.example.collageify.adapters;
 
 import android.content.Context;
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
-import com.example.collageify.databinding.ItemRecommendedTrackBinding;
+import com.example.collageify.R;
 import com.example.collageify.models.Song;
 
 import java.util.List;
 
 public class RecommendedTracksAdapter extends RecyclerView.Adapter<RecommendedTracksAdapter.ViewHolder> {
 
-    private Context context;
-    private List<Song> recommendedTracks;
-    private ItemRecommendedTrackBinding binding;
+    private final Context context;
+    private final List<Song> recommendedTracks;
 
     public RecommendedTracksAdapter(Context context, List<Song> recommendedTracks) {
         this.context = context;
@@ -27,10 +29,8 @@ public class RecommendedTracksAdapter extends RecyclerView.Adapter<RecommendedTr
     @NonNull
     @Override
     public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        binding = ItemRecommendedTrackBinding.inflate(LayoutInflater.from(context), parent, false);
-        ViewHolder viewHolder = new ViewHolder(binding);
-        viewHolder.setIsRecyclable(false);
-        return viewHolder;
+        View view = LayoutInflater.from(context).inflate(R.layout.item_recommended_track, parent, false);
+        return new ViewHolder(view);
     }
 
     @Override
@@ -46,14 +46,21 @@ public class RecommendedTracksAdapter extends RecyclerView.Adapter<RecommendedTr
 
     public class ViewHolder extends RecyclerView.ViewHolder {
 
-        public ViewHolder(@NonNull ItemRecommendedTrackBinding binding) {
-            super(binding.getRoot());
+        private final TextView tvTrackName;
+        private final TextView tvArtistName;
+        private final ImageView ivImage;
+
+        public ViewHolder(@NonNull View itemView) {
+            super(itemView);
+            tvTrackName = itemView.findViewById(R.id.tvTrackName);
+            tvArtistName = itemView.findViewById(R.id.tvArtistName);
+            ivImage = itemView.findViewById(R.id.ivImage);
         }
 
         public void bind(Song song) {
-            binding.tvTrackName.setText(song.getName());
-            binding.tvArtistName.setText(song.getArtistName());
-            Glide.with(context).load(song.getAlbumImageUrl()).into(binding.ivImage);
+            tvTrackName.setText(song.getName());
+            tvArtistName.setText(song.getArtistName());
+            Glide.with(context).load(song.getAlbumImageUrl()).into(ivImage);
         }
     }
 }


### PR DESCRIPTION
- view binding within adapters caused problems with recycler views—upon scrolling, items were duplicated in view instead of being recycled properly
    - found that the issue could be addressed by setting "isRecyclable" to false, but this would prevent the recycler views from utilizing memory efficiently 
    - as a result, decided to remove view binding for adapters